### PR TITLE
chore: add consortia snapshot1 calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ This program is to allow EnergyWeb to fairly select blocks at which staking snap
 EnergyWeb's approach for selection of the snapshot block is as follows:
 1. Select a blocknumber range (start and end blocknumbers) from which a snapshot block is to be calculated
 1. Obtain the blockhash of a block to use as a seed value.
-   If EnergyWeb commits to use the blockhash of a future block, this is a source of randomness which is difficult enough to influence or predict.
+   If EnergyWeb commits to use the blockhash of a future block using [SnapshotSeedRegistration contract](https://explorer.energyweb.org/address/0x4A0F475c59c9453B29c66548DB86f6557a75F448/transactions)
 1. Calculate a blocknumber within the random using this [program](./src/lib.rs)
+
+## Calculated Snapshot Blocks
+
+- Snapshot 1: [18059849](https://explorer.energyweb.org/block/18059849/transactions)
 
 ## Build
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@ use snapshot_block_calculator::calc_snapshot_block;
 /// Executes calc_snapshot_block.
 /// Change values as necessary.
 fn main() {
-  let start_block: u32 = 17690000; // https://explorer.energyweb.org/block/17690000/transactions
-  let end_block:u32 = 18200000; // https://explorer.energyweb.org/block/18200000/transactions
-  let block_hash = "0xfdd6d56dc922bf093cd69abb72f4b1d33d1a4a9cd7978a04c59f97ad0345bada"; // https://explorer.energyweb.org/block/18778013/transactions
+  let start_block: u32 = 17675146; // https://explorer.energyweb.org/block/17675146/transactions
+  let end_block:u32 = 18197775; // https://explorer.energyweb.org/block/18197775/transactions
+  let block_hash = "0x5a4cd6525687101f7143e27b961fc7ef999d10fc8937bcce9c9d2796bd3f19eb"; // https://explorer.energyweb.org/block/18812000/transactions
   println!("{}", calc_snapshot_block(start_block, end_block, block_hash));
 }
 

--- a/tests/calc_snapshot_block.rs
+++ b/tests/calc_snapshot_block.rs
@@ -60,4 +60,16 @@ mod calc_snapshot_block {
       let output2= calc_snapshot_block(start_block, end_block, block_hash_2);
       assert_ne!(output1, output2);
     }
+
+    #[test]
+    fn test_consortia_snapshot1() {
+      let start_block: u32 = 17675146; // https://explorer.energyweb.org/block/17675146/transactions
+      let end_block:u32 = 18197775; // https://explorer.energyweb.org/block/18197775/transactions
+      let block_hash = "0x5a4cd6525687101f7143e27b961fc7ef999d10fc8937bcce9c9d2796bd3f19eb"; // https://explorer.energyweb.org/block/18812000/transactions
+      let output = calc_snapshot_block(start_block, end_block, block_hash);
+      assert_eq!(output, 18059849); // https://explorer.energyweb.org/block/18059849/transactions
+      assert!(output > start_block);
+      assert!(output < end_block);
+    }
+
 }


### PR DESCRIPTION
Used calculator to determine that first snapshot block is [18059849](https://explorer.energyweb.org/block/18059849/transactions)
 (May-23-2022 11:55:45 PM +2 UTC)